### PR TITLE
Fix link to notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ automation, etc.
 | Info                                   | Link                                                                                                     |
 | -------------------------------------  | ---------------------------------------------------------------------------------------------------------|
 | **Basic Roadmap**                      | <a href='./roadmap.md' target="_blank">Click Here</a>                                                    |
-| **Complete Notes**                     | [Python Notes](https://github.com/thegeekyb0y/learnpython/blob/main/Python%20Notes%20(goalkicker))       |   
+| **Complete Notes**                     | [Python Notes](https://github.com/thegeekyb0y/learnpython/raw/main/Python%20Notes%20(goalkicker).pdf)       |   
 | **Python Libraries & Frameworks**      | [Awesome Python](https://github.com/vinta/awesome-python)                                                |
 
 ---


### PR DESCRIPTION
The current link https://github.com/thegeekyb0y/learnpython/blob/main/Python%20Notes%20(goalkicker) is a 404.

I also switched from `blob` to `raw` so that it downloads the PDF, viewing a PDF in GitHub seems weird.